### PR TITLE
:sparkles: create redux store setup function

### DIFF
--- a/src/store/setup-store.ts
+++ b/src/store/setup-store.ts
@@ -1,0 +1,16 @@
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import createSagaMiddleware from 'redux-saga';
+
+export const rootReducer = combineReducers({});
+
+export type RootState = ReturnType<typeof rootReducer>;
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const setupStore = () => {
+  const saga = createSagaMiddleware();
+  const store = configureStore({
+    reducer: rootReducer,
+    middleware: (getDefault) => getDefault({ thunk: false }).concat(saga),
+  });
+  return store;
+};


### PR DESCRIPTION
supress explicit-module-boundary-types warning.
because use return-type of @reduxjs/toolkit as it is.